### PR TITLE
Detect Row Win Condition

### DIFF
--- a/lib/GameLogic/gameLogic.js
+++ b/lib/GameLogic/gameLogic.js
@@ -11,8 +11,8 @@ export class GameLogic {
     
     // private #findRowWin(): String || Boolean
     #findRowWin() {
-        const winCombo = this.token.repeat(this.board.columnTotal);
-        const winningRow = this.board.cells.filter((row) => row.join('') === winCombo);
+        const winningRow = this.board.cells.filter((row) => 
+            row.join('') === this.token.repeat(this.board.columnTotal));
         return winningRow.length !== 0 ? winningRow.flat()[0] : false;
     };
 }; 

--- a/lib/GameLogic/gameLogic.js
+++ b/lib/GameLogic/gameLogic.js
@@ -1,0 +1,18 @@
+export class GameLogic {
+    constructor(board, currentPlayerToken) {
+        this.board = board;
+        this.token = currentPlayerToken;
+    };
+
+    // public detectRowWin(): Boolean
+    detectRowWin() {
+        return this.#findRowWin() !== false;
+    };
+    
+    // private #findRowWin(): String || Boolean
+    #findRowWin() {
+        const winCombo = this.token.repeat(this.board.columnTotal);
+        const winningRow = this.board.cells.filter((row) => row.join('') === winCombo);
+        return winningRow.length !== 0 ? winningRow.flat()[0] : false;
+    };
+}; 

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -1,0 +1,36 @@
+import { GameLogic } from "../../lib/GameLogic/gameLogic";
+import { Board } from "../../lib/Board/board";
+import { Token } from "../../lib/Token/token";
+
+describe('GameLogic', () => {
+
+    let board;
+    let playerToken;
+    let game;
+
+    beforeEach(() => {
+        board = new Board();
+        playerToken = new Token('X').getToken();
+        game = new GameLogic(board, playerToken);
+    });
+
+    describe('isWin()', () => {
+        test('will return a true boolean value when a row filled with the same token is detected', () => {
+            board.placeToken(playerToken, 1);
+            board.placeToken(playerToken, 2);
+            board.placeToken(playerToken, 3);
+
+            const gameWinDetected = game.detectRowWin();
+            expect(gameWinDetected).toBeTruthy();
+        });
+
+        test('will return a false boolean value when a row filled with the same token is not detected', () => {
+            board.placeToken(playerToken, 1);
+            board.placeToken(playerToken, 2);
+            board.placeToken(playerToken='O', 3);
+
+            const gameWinDetected = game.detectRowWin();
+            expect(gameWinDetected).toBeFalsy(); 
+        });
+    });
+});

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -12,20 +12,49 @@ describe('GameLogic', () => {
         board = new Board();
         playerToken = new Token('X').getToken();
         game = new GameLogic(board, playerToken);  
-        
-        board.placeToken(playerToken, 1);
-        board.placeToken(playerToken, 2);
     });
 
     describe('detectRowWin()', () => {
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            board.placeToken(playerToken, 3); // 'X' | 'X' | 'X' 
+            // X | X  | X 
+            // ''| '' | ''
+            // ''| '' | ''
+            board.placeToken(playerToken, 1);
+            board.placeToken(playerToken, 2);
+            board.placeToken(playerToken, 3);
+            const gameWinDetected = game.detectRowWin();
+            expect(gameWinDetected).toBeTruthy();
+        });
+
+        test('will return a true boolean value when a row filled with the same token is detected', () => {
+            // '' | '' | ''
+            // X  | X  | X
+            // '' | '' | ''
+            board.placeToken(playerToken, 4);
+            board.placeToken(playerToken, 5);
+            board.placeToken(playerToken, 6); 
+            const gameWinDetected = game.detectRowWin();
+            expect(gameWinDetected).toBeTruthy();
+        });
+        
+        test('will return a true boolean value when a row filled with the same token is detected', () => {
+            // '' | '' | ''
+            // '' | '' | ''
+            // X  | X  | X
+            board.placeToken(playerToken, 7);
+            board.placeToken(playerToken, 8);
+            board.placeToken(playerToken, 9); 
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeTruthy();
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
-            board.placeToken(playerToken='O', 3); // 'X' | 'X' | 'O'
+            // X  | X  | O
+            // '' | '' | ''
+            // '' | '' | ''
+            board.placeToken(playerToken, 1);
+            board.placeToken(playerToken, 2);
+            board.placeToken(playerToken = 'O', 3); // 'X' | 'X' | 'O'
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeFalsy(); 
         });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -4,45 +4,35 @@ import { Token } from "../../lib/Token/token";
 
 describe('GameLogic', () => {
 
-    let playerToken;
-    let board;
-    let game;
-
-    beforeEach(() => {
-        board = new Board();
-        playerToken = new Token('X').getToken();
-        game = new GameLogic(board, playerToken);  
-    });
-
     describe('detectRowWin()', () => {
-        test('will return a true boolean value when a row filled with the same token is detected', () => {
-            let positions = [1, 2, 3]
-            positions.map((cell) => board.placeToken(playerToken, cell))
-            const gameWinDetected = game.detectRowWin();
-            expect(gameWinDetected).toBeTruthy();
-        });
-
-        test('will return a true boolean value when a row filled with the same token is detected', () => {
-            let positions = [4, 5, 6]
-            positions.map((cell) => board.placeToken(playerToken, cell))
-            const gameWinDetected = game.detectRowWin();
-            expect(gameWinDetected).toBeTruthy();
-        });
+        const playerToken = new Token('X').getToken();
+        const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
         
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            let positions = [7, 8, 9]
-            positions.map((cell) => board.placeToken(playerToken, cell))
-            const gameWinDetected = game.detectRowWin()
-            expect(gameWinDetected).toBeTruthy();
+            let positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+            
+            positions.map((row) => { 
+                let board = new Board();
+                let game = new GameLogic(board, playerToken);
+                row.map((col) => {
+                    placeTokenFunc(col, board); 
+                });
+
+                const gameWinDetected = game.detectRowWin();
+                expect(gameWinDetected).toEqual(true);
+            });
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
-            let positions = [1, 2, 3]
-            positions.map((cell, index) => (index + 1 !== positions[positions.length - 1]) ? 
-                board.placeToken(new Token('X').getToken(), cell) 
+            let board = new Board()
+            let game = new GameLogic(board, playerToken);
+            let positions = [1, 2, 3];
+            positions.map((cell, index) => (index + 1 !== positions[positions.length - 1]) ?
+                board.placeToken(playerToken, cell)
                 : board.placeToken(new Token('O').getToken(), cell));
+            
             const gameWinDetected = game.detectRowWin();
-            expect(gameWinDetected).toBeFalsy(); 
+            expect(gameWinDetected).toEqual(false);
         });
     });
 });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -4,8 +4,8 @@ import { Token } from "../../lib/Token/token";
 
 describe('GameLogic', () => {
 
-    let board;
     let playerToken;
+    let board;
     let game;
 
     beforeEach(() => {
@@ -16,45 +16,31 @@ describe('GameLogic', () => {
 
     describe('detectRowWin()', () => {
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            // X | X  | X 
-            // ''| '' | ''
-            // ''| '' | ''
-            board.placeToken(playerToken, 1);
-            board.placeToken(playerToken, 2);
-            board.placeToken(playerToken, 3);
+            let positions = [1, 2, 3]
+            positions.map((cell) => board.placeToken(playerToken, cell))
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeTruthy();
         });
 
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            // '' | '' | ''
-            // X  | X  | X
-            // '' | '' | ''
-            board.placeToken(playerToken, 4);
-            board.placeToken(playerToken, 5);
-            board.placeToken(playerToken, 6); 
+            let positions = [4, 5, 6]
+            positions.map((cell) => board.placeToken(playerToken, cell))
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeTruthy();
         });
         
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            // '' | '' | ''
-            // '' | '' | ''
-            // X  | X  | X
-            board.placeToken(playerToken, 7);
-            board.placeToken(playerToken, 8);
-            board.placeToken(playerToken, 9); 
-            const gameWinDetected = game.detectRowWin();
+            let positions = [7, 8, 9]
+            positions.map((cell) => board.placeToken(playerToken, cell))
+            const gameWinDetected = game.detectRowWin()
             expect(gameWinDetected).toBeTruthy();
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
-            // X  | X  | O
-            // '' | '' | ''
-            // '' | '' | ''
-            board.placeToken(playerToken, 1);
-            board.placeToken(playerToken, 2);
-            board.placeToken(playerToken = 'O', 3); // 'X' | 'X' | 'O'
+            let positions = [1, 2, 3]
+            positions.map((cell, index) => (index + 1 !== positions[positions.length - 1]) ? 
+                board.placeToken(new Token('X').getToken(), cell) 
+                : board.placeToken(new Token('O').getToken(), cell));
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeFalsy(); 
         });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -11,24 +11,21 @@ describe('GameLogic', () => {
     beforeEach(() => {
         board = new Board();
         playerToken = new Token('X').getToken();
-        game = new GameLogic(board, playerToken);
+        game = new GameLogic(board, playerToken);  
+        
+        board.placeToken(playerToken, 1);
+        board.placeToken(playerToken, 2);
     });
 
     describe('detectRowWin()', () => {
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            board.placeToken(playerToken, 1);
-            board.placeToken(playerToken, 2);
-            board.placeToken(playerToken, 3);
-
+            board.placeToken(playerToken, 3); // 'X' | 'X' | 'X' 
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeTruthy();
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
-            board.placeToken(playerToken, 1);
-            board.placeToken(playerToken, 2);
-            board.placeToken(playerToken='O', 3);
-
+            board.placeToken(playerToken='O', 3); // 'X' | 'X' | 'O'
             const gameWinDetected = game.detectRowWin();
             expect(gameWinDetected).toBeFalsy(); 
         });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -14,7 +14,7 @@ describe('GameLogic', () => {
         game = new GameLogic(board, playerToken);
     });
 
-    describe('isWin()', () => {
+    describe('detectRowWin()', () => {
         test('will return a true boolean value when a row filled with the same token is detected', () => {
             board.placeToken(playerToken, 1);
             board.placeToken(playerToken, 2);


### PR DESCRIPTION
# Detect Row Win Condition

This branch adds the functionality to detect when/if a single row of the board contains the exact same player token. This feature can be used alternatively between two players as they place tokens on the board to check for a winning row based on the necessary conditions.

### Type of Change

- New Feature (non-breaking change which adds functionality)

### Tests

- Test Suite: `gameLogic.test.js`

Tests that a boolean value can be returned when `detectRowWin()` is called.