### PR TITLE
Detect Winner Token Based On Row Win Condition

### DIFF
--- a/lib/GameLogic/gameLogic.js
+++ b/lib/GameLogic/gameLogic.js
@@ -6,13 +6,17 @@ export class GameLogic {
 
     // public detectRowWin(): Boolean
     detectRowWin() {
-        return this.#findRowWin() !== false;
+        return this.#findRowWin().length !== 0;
+    };
+
+    // public getWinningToken(): String || null
+    getWinningToken() {
+        return this.detectRowWin() ? this.token : null;
     };
     
     // private #findRowWin(): String || Boolean
     #findRowWin() {
-        const winningRow = this.board.cells.filter((row) => 
+        return this.board.cells.filter((row) => 
             row.join('') === this.token.repeat(this.board.columnTotal));
-        return winningRow.length !== 0 ? winningRow.flat()[0] : false;
     };
 }; 

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -3,26 +3,26 @@ import { Board } from "../../lib/Board/board";
 import { Token } from "../../lib/Token/token";
 
 describe('GameLogic', () => {
-    describe('detectRowWin()', () => {
-        const board = new Board();
-        const playerToken = new Token('X').getToken();
-        const game = new GameLogic(board, playerToken); 
-        const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
-        
+    const playerToken = new Token('X').getToken();  
+    
+    describe('detectRowWin()', () => { 
         test('will return a true boolean value when a row filled with the same token is detected', () => {
             const positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
-            positions.map((row) => { 
+            const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
+            positions.forEach((row) => { 
                 const board = new Board();
                 const game = new GameLogic(board, playerToken);
-                row.map((col) => placeTokenFunc(col, board));
+                row.forEach((col) => placeTokenFunc(col, board));
                 const winDetected = game.detectRowWin();
                 expect(winDetected).toEqual(true);
             });
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
+            const board = new Board();
+            const game = new GameLogic(board, playerToken);
             const positions = [1, 2, 3];
-            positions.map((cell) => !positions[positions.length - 1] ? 
+            positions.forEach((cell) => !positions[positions.length - 1] ? 
                 board.placeToken(playerToken, cell) : board.placeToken(new Token('O').getToken(), cell));    
             const winDetected = game.detectRowWin();
             expect(winDetected).toEqual(false);
@@ -30,23 +30,27 @@ describe('GameLogic', () => {
     });
 
     describe('getWinningToken()', () => {
-        const board = new Board();
-        const playerToken = new Token('X').getToken();
-        const game = new GameLogic(board, playerToken);
-        const placeTokenFunc = (cell) => board.placeToken(playerToken, cell);
+        let board;
+        let game;
         const positions = [1, 2, 3];
 
+        beforeEach(() => {
+            board = new Board();
+            game = new GameLogic(board, playerToken);
+        });
+        
         test('will return a string representation of the winning player\'s token', () => { 
-            positions.map(placeTokenFunc);
+            const placeTokenFunc = (cell) => board.placeToken(playerToken, cell);
+            positions.forEach(placeTokenFunc);
             const winner = game.getWinningToken();
             expect(winner).toEqual('X');
         });
 
         test('will return a null value if no winning player is found', () => {
-            positions.map((cell) => !positions[positions.length - 1] ? 
-                board.placeToken(playerToken, cell) : board.placeToken(playerToken, cell));
+            positions.forEach((cell) => !positions[positions.length - 1] ? 
+                board.placeToken(playerToken, cell) : board.placeToken(new Token('O').getToken(), cell));
             const winner = game.getWinningToken();
-            expect(winner).toEqual('X');
+            expect(winner).toEqual(null);
         });
     });
 });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -3,36 +3,50 @@ import { Board } from "../../lib/Board/board";
 import { Token } from "../../lib/Token/token";
 
 describe('GameLogic', () => {
-
     describe('detectRowWin()', () => {
+        const board = new Board();
         const playerToken = new Token('X').getToken();
+        const game = new GameLogic(board, playerToken); 
         const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
         
         test('will return a true boolean value when a row filled with the same token is detected', () => {
-            let positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
-            
+            const positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
             positions.map((row) => { 
-                let board = new Board();
-                let game = new GameLogic(board, playerToken);
-                row.map((col) => {
-                    placeTokenFunc(col, board); 
-                });
-
-                const gameWinDetected = game.detectRowWin();
-                expect(gameWinDetected).toEqual(true);
+                const board = new Board();
+                const game = new GameLogic(board, playerToken);
+                row.map((col) => placeTokenFunc(col, board));
+                const winDetected = game.detectRowWin();
+                expect(winDetected).toEqual(true);
             });
         });
 
         test('will return a false boolean value when a row filled with the same token is not detected', () => {
-            let board = new Board()
-            let game = new GameLogic(board, playerToken);
-            let positions = [1, 2, 3];
-            positions.map((cell, index) => (index + 1 !== positions[positions.length - 1]) ?
-                board.placeToken(playerToken, cell)
-                : board.placeToken(new Token('O').getToken(), cell));
-            
-            const gameWinDetected = game.detectRowWin();
-            expect(gameWinDetected).toEqual(false);
+            const positions = [1, 2, 3];
+            positions.map((cell) => !positions[positions.length - 1] ? 
+                board.placeToken(playerToken, cell) : board.placeToken(new Token('O').getToken(), cell));    
+            const winDetected = game.detectRowWin();
+            expect(winDetected).toEqual(false);
+        });
+    });
+
+    describe('getWinningToken()', () => {
+        const board = new Board();
+        const playerToken = new Token('X').getToken();
+        const game = new GameLogic(board, playerToken);
+        const placeTokenFunc = (cell) => board.placeToken(playerToken, cell);
+        const positions = [1, 2, 3];
+
+        test('will return a string token of the winning player', () => { 
+            positions.map(placeTokenFunc);
+            const winner = game.getWinningToken();
+            expect(winner).toEqual('X');
+        });
+
+        test('will return a null value if no winning player is found', () => {
+            positions.map((cell) => !positions[positions.length - 1] ? 
+                board.placeToken(playerToken, cell) : board.placeToken(playerToken, cell));
+            const winner = game.getWinningToken();
+            expect(winner).toEqual('X');
         });
     });
 });

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -36,7 +36,7 @@ describe('GameLogic', () => {
         const placeTokenFunc = (cell) => board.placeToken(playerToken, cell);
         const positions = [1, 2, 3];
 
-        test('will return a string token of the winning player', () => { 
+        test('will return a string representation of the winning player\'s token', () => { 
             positions.map(placeTokenFunc);
             const winner = game.getWinningToken();
             expect(winner).toEqual('X');


### PR DESCRIPTION
# Detect Winner Token Based On Row Win Condition

This branch adds the functionality to return a player's token if the row win condition in satisfied. This feature can be used alternatively between two players as they place tokens on the board to ensure the winner is identified as moves are made throughout the duration of the game.

### Type of Change

- New Feature (non-breaking change which adds functionality)

### Tests

- Test Suite: `gameLogic.test.js`

Tests that a winning token object can be returned if the row win condition is satisfied.

Tests that `null` is returned if a row win condition is not satisfied.