### PR TITLE
Randomly Fill Board With Tokens Until Game Is Over

### DIFF
--- a/lib/Board/board.js
+++ b/lib/Board/board.js
@@ -63,8 +63,24 @@ export class Board {
 
     // public isFilledWithTokens(): Boolean
     isFilledWithTokens() {
-        const isEmptyCell = (row, col) => row[col] === ('');
-        return this.cells.every((row, col) => !isEmptyCell(row, col));
+        const isEmptyCell = (cell) => cell === ('');
+        return this.getCells().every((row) => row.every((col) => !isEmptyCell(col)));
+    };
+
+    // public placeTokenInRandomPosition(token: Token): void 
+    placeTokenInRandomPosition(token) {
+        const min = 1;
+        const max = this.rowTotal * this.columnTotal;
+        let randomPosition = this.#getRandomPosition(min, max)
+        
+        this.#isValidCell(randomPosition) 
+            ? (this.placeToken(token.getCurrentPlayerTokenObj(), randomPosition), token.alternatePlayers())
+            : randomPosition = this.#getRandomPosition(min, max);
+    };
+
+    // private getRandomPosition(min: Number, max: Number): Number
+    #getRandomPosition(min, max) {
+        return Math.floor((Math.random()) * (max - min + 1) + (min));
     };
 
     // private #getRow(position: Number): Number

--- a/lib/Computer/computer.js
+++ b/lib/Computer/computer.js
@@ -1,0 +1,17 @@
+export class Computer {
+    constructor(token1, token2) {
+        this.player1 = token1,
+        this.player2 = token2,
+        this.currentPlayer = this.player1
+    };
+
+    // public getCurrentPlayerTokenObj(): Token
+    getCurrentPlayerTokenObj() {
+        return this.currentPlayer;   
+    };
+
+    // public alternatePlayers(): void
+    alternatePlayers() {
+        this.currentPlayer === this.player1 ? this.currentPlayer = this.player2 : this.currentPlayer = this.player1;
+    };
+};

--- a/lib/GameLogic/gameLogic.js
+++ b/lib/GameLogic/gameLogic.js
@@ -1,18 +1,26 @@
 export class GameLogic {
-    constructor(board, currentPlayerToken) {
+    constructor(board, player1, player2) {
         this.board = board;
-        this.playerToken = currentPlayerToken;
+        this.player1 = player1.getToken();
+        this.player2 = player2.getToken();
     };
 
     // public getWinningToken(): String || null
     getWinningToken() {
-        return (
-            this.#containsWinningRow()
-                || this.#containsWinningColumn()
-                || this.#containsWinningMainDiagonal()
-                || this.#containsWinningCounterDiagonal()
-                ? this.playerToken : null
-        );
+        const winConditions =
+            [
+                { 'winCondition': this.#containsWinningRow(), 'winner': this.#hasWinningRow() },
+                { 'winCondition': this.#containsWinningColumn(), 'winner': this.#hasWinningColumn() },
+                { 'winCondition': this.#containsWinningMainDiagonal(), 'winner': this.#hasWinningMainDiagonal() },
+                { 'winCondition': this.#containsWinningCounterDiagonal(), 'winner': this.#hasWinningCounterDiagonal() }
+            ]
+        
+        for (const condition of winConditions) {
+            if (condition.winCondition) {
+                return condition.winner[0];
+            };
+        };
+        return null;
     };
 
     // private containsWinningRow: Boolean
@@ -37,7 +45,8 @@ export class GameLogic {
 
     // private #isWinner(tokenArr: Array): Boolean
     #isWinner(tokenArr) {
-        return tokenArr.join('') === this.playerToken.repeat(this.board.columnTotal);
+        return tokenArr.join('') === this.player1.repeat(this.board.columnTotal)
+            || tokenArr.join('') === this.player2.repeat(this.board.columnTotal);
     };
 
     // private #hasWinningTokenCombination(tokenArr: Arr): Array
@@ -49,7 +58,7 @@ export class GameLogic {
     // private #hasWinningRow(): Array
     #hasWinningRow() {
         const winningRow = (rowArr) => this.#isWinner(rowArr);
-        return this.board.getCells().find(winningRow) || [];
+        return (this.board.getCells().find(winningRow)) || ([]);
     };
 
     // private #hasWinningColumn(): Array

--- a/lib/TicTacToe/ticTacToe.js
+++ b/lib/TicTacToe/ticTacToe.js
@@ -3,12 +3,13 @@ import { Display } from '../Display/display.js'
 import { UserPrompts } from '../UserPrompts/userPrompts.js';
 import { GameLogic } from '../GameLogic/gameLogic.js';
 import { Token } from '../Token/token.js';
+import { Computer } from '../Computer/computer.js';
 export class TicTacToe {
-    constructor(board, display, logic, token, prompts) {
+    constructor(board, display, logic, computer, prompts) {
         this.board = board;
         this.display = display;
         this.logic = logic;
-        this.token = token;
+        this.computer = computer;
         this.prompts = prompts;
     };
 
@@ -16,18 +17,24 @@ export class TicTacToe {
     run() {
         this.display.output(this.prompts.getWelcomePrompt());
         this.display.output(this.board.toString());
-
-        !logic.getWinningToken() 
-        ? this.display.output(this.prompts.getPlaceTokenPrompt()) 
-        : this.display.output(this.prompts.getGameOverPrompt());
+        while (!this.logic.getWinningToken()) {
+            if (this.board.isFilledWithTokens()) { return this.display.output(this.prompts.getGameOverPrompt()) };
+            this.display.output(this.prompts.getPlaceTokenPrompt());
+            this.board.placeTokenInRandomPosition(this.computer);
+            this.display.output(this.board.toString());
+        };
+        this.display.output(this.prompts.getGameOverPrompt());
+        this.display.output(this.logic.getWinningToken());  
     };
 };
 
 const board = new Board();
 const display = new Display();
-const token = new Token('X');
-const logic = new GameLogic(board, token.getToken());
+const player1 = new Token('X');
+const player2 = new Token('O');
+const computer = new Computer(player1, player2);
+const logic = new GameLogic(board, computer.player1, computer.player2);
 const prompts = new UserPrompts();
-const game = new TicTacToe(board, display, logic, token, prompts);
+const game = new TicTacToe(board, display, logic, computer, prompts);
 
 game.run();

--- a/test/Board/board.test.js
+++ b/test/Board/board.test.js
@@ -1,5 +1,6 @@
 import { Board } from '../../lib/Board/board'
 import { Token } from '../../lib/Token/token'
+import { Computer } from '../../lib/Computer/computer'
 
 describe('Board', () => {
     let board;
@@ -62,7 +63,7 @@ describe('Board', () => {
         });
     });
 
-describe('getCounterDiagonalCells()', () => {
+    describe('getCounterDiagonalCells()', () => {
         test('returns a data structure containing tokens detected in each main diagonal cell', () => {
             const token1 = new Token('?');
             const token2 = new Token('S');
@@ -81,7 +82,7 @@ describe('getCounterDiagonalCells()', () => {
 
         test('returns a true boolean value when all spaces in the board are filled', () => {
             const positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
-            positions.forEach((row) => row.forEach((col) => placeTokenFunc(col)));
+            positions.forEach((row, col) => row.forEach((col) => placeTokenFunc(col)));
             const fullBoardDetected = board.isFilledWithTokens();
             expect(fullBoardDetected).toBe(true);
         });
@@ -93,6 +94,16 @@ describe('getCounterDiagonalCells()', () => {
             expect(fullBoardDetected).toBe(false);
         });
     });
+
+    describe('placeTokenInRandomPosition()', () => {
+        test('updates the board for the current computer player by placing a token in a random position IF position is valid', () => {
+            const player1 = new Token('X')
+            const computerPlayer = new Computer(player1, new Token('O'));
+            const potentialRowMatches = [[['X','','']], [['','X','']], [['','','X']], []];
+            const hasUpdatedRow = (row, col) => row[col] === player1.getToken();
+            board.placeTokenInRandomPosition(computerPlayer);
+            const rowWithToken = board.getCells().filter((row, col) => hasUpdatedRow(row, col))
+            expect(potentialRowMatches).toContainEqual(rowWithToken)
+        });
+    });
 });
-
-

--- a/test/Computer/computer.test.js
+++ b/test/Computer/computer.test.js
@@ -1,0 +1,22 @@
+import { Computer } from '../../lib/Computer/computer'
+import { Token } from '../../lib/Token/token';
+import { Board } from '../../lib/Board/board';
+
+describe('Computer', () => {
+    const player1 = new Token('X');
+    const player2 = new Token('O');
+    const computer = new Computer(player1, player2);
+
+    test('will return the current player\'s token object', () => {
+        const firstMove = computer.getCurrentPlayerTokenObj();
+        expect(firstMove).toEqual({"playerToken": "X"})
+    });
+
+    test('will return the opponent player\'s token object after the players are alternated', () => {
+        const firstMove = computer.getCurrentPlayerTokenObj();
+        computer.alternatePlayers()
+        const secondMove = computer.getCurrentPlayerTokenObj();
+        expect(firstMove).toEqual({"playerToken": "X"});
+        expect(secondMove).toEqual({"playerToken": "O"});
+    });
+});

--- a/test/GameLogic/gameLogic.test.js
+++ b/test/GameLogic/gameLogic.test.js
@@ -4,15 +4,16 @@ import { Token } from "../../lib/Token/token";
 
 describe('getWinningToken()', () => {
 
-    const playerToken = new Token('X');
+    const player1 = new Token('X');
+    const player2 = new Token('O')
 
     describe('detects winning row combination', () => {
         test('will return a true boolean value when a row win is detected', () => {
             const positions = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
-            const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
+            const placeTokenFunc = (col, board) => board.placeToken(player1, col);
             positions.forEach((row) => {
                 const board = new Board();
-                const game = new GameLogic(board, playerToken.getToken());
+                const game = new GameLogic(board, player1, player2);
                 row.forEach((col) => placeTokenFunc(col, board));
                 const winDetected = game.getWinningToken() != null;
                 expect(winDetected).toEqual(true);
@@ -22,10 +23,9 @@ describe('getWinningToken()', () => {
         test('will return a false boolean value when a row win is not detected', () => {
             const positions = [1, 2, 3];
             const board = new Board();
-            const playerToken2 = new Token('O');
-            const game = new GameLogic(board, playerToken.getToken());
-            const placeTokenFunc = (cell) => cell != positions[positions.length - 1] ? board.placeToken(playerToken, cell) : board.placeToken(playerToken2, cell);
-            positions.forEach(placeTokenFunc);
+            const game = new GameLogic(board, player1, player2);
+            const placeTokenFunc = (col) => col != positions[positions.length - 1] ? board.placeToken(player1, col) : board.placeToken(player2, col);
+            positions.forEach((col) => placeTokenFunc(col));
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toEqual(false);
         });
@@ -34,10 +34,10 @@ describe('getWinningToken()', () => {
     describe('detects winning column combination', () => {
         test('will return a true boolean value when a column win is detected', () => {
             const positions = [[1, 4, 7], [2, 5, 8], [3, 6, 9]];
-            const placeTokenFunc = (cell, board) => board.placeToken(playerToken, cell);
+            const placeTokenFunc = (cell, board) => board.placeToken(player1, cell);
             positions.forEach((row) => {
                 const board = new Board();
-                const game = new GameLogic(board, playerToken.getToken());
+                const game = new GameLogic(board, player1, player2);
                 row.forEach((col) => placeTokenFunc(col, board));
                 const winDetected = game.getWinningToken() != null;
                 expect(winDetected).toEqual(true);
@@ -47,10 +47,9 @@ describe('getWinningToken()', () => {
         test('will return a false boolean value when a column win is not detected', () => {
             const positions = [1, 4, 7];
             const board = new Board();
-            const game = new GameLogic(board, playerToken.getToken());
-            const playerToken2 = new Token('O');
-            const placeTokenFunc = (cell) => cell != positions[positions.length - 1] ? board.placeToken(playerToken, cell) : board.placeToken(playerToken2, cell);
-            positions.forEach(placeTokenFunc)
+            const game = new GameLogic(board, player1, player2);
+            const placeTokenFunc = (col) => col != positions[positions.length - 1] ? board.placeToken(player1, col) : board.placeToken(player2, col);
+            positions.forEach(placeTokenFunc);
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toEqual(false);
         });
@@ -62,12 +61,12 @@ describe('getWinningToken()', () => {
         
         beforeEach(() => {
             board = new Board();
-            game = new GameLogic(board, playerToken.getToken());
+            game = new GameLogic(board, player1, player2);
         });
 
         test('will return a true boolean value when a main diagonal win (top-left to bottom-right) is detected', () => {
             const positions = [1, 5, 9];
-            const placeTokenFunc = (cell) => board.placeToken(playerToken, cell);
+            const placeTokenFunc = (cell) => board.placeToken(player1, cell);
             positions.forEach(placeTokenFunc);
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toBe(true);
@@ -75,8 +74,7 @@ describe('getWinningToken()', () => {
 
         test('will return a false boolean value when a main diagonal win (top-left to bottom-right) is not detected', () => {
             const positions = [1, 5, 9];
-            const playerToken2 = new Token('O')
-            const placeTokenFunc = (cell) => cell != positions[positions.length - 1] ? board.placeToken(playerToken, cell) : board.placeToken(playerToken2, cell);
+            const placeTokenFunc = (col) => col != positions[positions.length - 1] ? board.placeToken(player1, col) : board.placeToken(player2, col);
             positions.forEach(placeTokenFunc);
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toEqual(false);
@@ -89,20 +87,21 @@ describe('getWinningToken()', () => {
 
         beforeEach(() => {
             board = new Board();
-            game = new GameLogic(board, playerToken.getToken());
+            game = new GameLogic(board, player1, player2);
         });
 
         test('will return a true boolean value when a counter diagonal win (top-right to bottom-left) is detected', () => {
             const positions = [3, 5, 7];
-            const placeTokenFunc = (cell) => board.placeToken(playerToken, cell)
+            const placeTokenFunc = (cell) => board.placeToken(player1, cell)
             positions.forEach(placeTokenFunc);
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toBe(true);
         });
+        
         test('will return a false boolean value when a counter diagonal win (top-right to bottom-left) is not detected', () => {
             const positions = [3, 5];
             const playerToken2 = new Token('O')
-            const placeTokenFunc = (cell) => cell != positions[positions.length - 1] ? board.placeToken(playerToken, cell) : board.placeToken(playerToken2, cell);
+            const placeTokenFunc = (col) => col != positions[positions.length - 1] ? board.placeToken(player1, col) : board.placeToken(player2, col);
             positions.forEach(placeTokenFunc);
             const winDetected = game.getWinningToken() != null;
             expect(winDetected).toEqual(false);


### PR DESCRIPTION
# Randomly Fill Board With Tokens Until Game Is Over

## Description
This branch allows a board to be filled with two computer player's tokens in randomly generated positions. The board will continue to be filled with randomly generated tokens so long as a winner has not been detected within the board, and/or the game has not ended. It also allows a computer player to continue searching for an unoccupied random position within the board if it does not initially find it. 

### Type of Change
New Feature (non-breaking change that extends functionality)

### Tests
- `board.test.js`
Tests that the `placeTokenInRandomPosition()` method updates the board for the current computer player by placing a token in a random position if the position is valid. 

- `computer.test.js`
Tests that the `Computer` returns the current and/or opponent player's token object based on alternating moves.

- `gameLogic.test.js`
Tests that the `getWinningToken()` method returns the correct player's token if they've been identified as a winner.
